### PR TITLE
Adding tests for `adjust_time`

### DIFF
--- a/tests/test_adjust_time.py
+++ b/tests/test_adjust_time.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from operator import attrgetter
+from pathlib import Path
+
+import pytest
+from symusic import Note, Score, Track
+
+from tests.utils import MIDI_PATHS
+
+# as tuples (original notes, original times, new times, expected notes)
+NOTES_OG = [Note(0, 4, 72, 72), Note(4, 6, 72, 72), Note(8, 14, 72, 72)]
+TEST_CASES = (
+    # Only shkrinks the [0,4] to [0,2]
+    (
+        NOTES_OG,
+        [0, 4],
+        [0, 2],
+        [
+            Note(0, 2, 72, 72),
+            Note(2, 4, 72, 72),
+            Note(6, 12, 72, 72),
+        ],
+    ),
+    # Identical to previous but pointlessly provide a third point
+    (
+        NOTES_OG,
+        [0, 4, 8],
+        [0, 2, 6],
+        [
+            Note(0, 2, 72, 72),
+            Note(2, 4, 72, 72),
+            Note(6, 12, 72, 72),
+        ],
+    ),
+)
+
+TIMES = (([2, 4], [1, 3]),)
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES)
+def test_adjust_time(test_case: tuple[list[Note], list[int], list[int], list[Note]]):
+    """Test the `adjust_time` method with hardcoded test cases."""
+    notes_og, times_og, times_new, notes_expected = test_case
+    midi = Score()
+    midi.tracks.append(Track(notes=notes_og))
+    midi_adjusted = midi.adjust_time(times_og, times_new)
+    assert midi_adjusted.tracks[0].notes == notes_expected
+
+
+@pytest.mark.parametrize("midi_path", MIDI_PATHS, ids=attrgetter("name"))
+@pytest.mark.parametrize("times", TIMES)
+def test_adjust_time_midi(midi_path: Path, times: tuple[list[int], list[int]]):
+    """Test the `adjust_time` method just by running it on test MIDIs."""
+    midi = Score(midi_path)
+    times_og = [time * midi.ticks_per_quarter for time in times[0]]
+    times_new = [time * midi.ticks_per_quarter for time in times[1]]
+    _ = midi.adjust_time(times_og, times_new)
+    # TODO assert something


### PR DESCRIPTION
**WIP**

Adds tests for `adjust_time` (#28)

Failing right now, I'm just opening the PR as a draft
Either I don't understand exactly how the method should used, or the method fails with these simples cases.
Am I correct using as it is, with the times provided in ticks?
When using `times[0, 4]` `[0, 2]` only the first note is kept. I thought that only the time portion provided were shrunk, the rest being "untouched", but actually the method will only keep the provided time range. Should we also consider uncovered ranges?
When using `times[0, 4, 8]` `[0, 2, 6]` the second and third notes have negative durations (-2 and -6 respectively).