### PR TITLE
Adding wheel for python 3.14

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -24,7 +24,7 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "pp39"]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314", "pp39"]
         exclude:
           - buildplat: [windows-2022, win32]
             python: "pp39"


### PR DESCRIPTION
Hi there, I hope you've been well since last time! :)

This PR adds python 3.14 to the wheels to build of the CI