### PR TITLE
Add experimental Python 3.14 runtime CI job and runtime-compatibility tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,48 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: python
 
+  py314_experimental_runtime_test:
+    name: Experimental runtime tests on Ubuntu (3.14 + JIT / 3.14t free-threaded)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.14"
+            enable-jit: "1"
+            expected-gil-disabled: "0"
+          - python-version: "3.14t"
+            enable-jit: "0"
+            expected-gil-disabled: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Show runtime info
+        run: |
+          python -VV
+          python -c "import sys, sysconfig; print('python_version=', sys.version); print('Py_GIL_DISABLED=', sysconfig.get_config_var('Py_GIL_DISABLED')); print('has_sys_jit=', hasattr(sys, '_jit'))"
+
+      - name: Install package and test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install ".[test]"
+
+      - name: Run full Python test suite under experimental runtime
+        env:
+          PYTHON_JIT: ${{ matrix.enable-jit }}
+          SYMUSIC_EXPECT_GIL_DISABLED: ${{ matrix.expected-gil-disabled }}
+        run: |
+          pytest -s -n auto --durations=0 -v tests
+
   cpp_test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tests/test_runtime_compatibility.py
+++ b/tests/test_runtime_compatibility.py
@@ -1,0 +1,61 @@
+"""Runtime compatibility tests for Python 3.14 JIT and free-threaded builds."""
+
+from __future__ import annotations
+
+import os
+import sys
+import sysconfig
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from symusic import Note, Score, Track
+
+
+def _is_gil_disabled_build() -> bool:
+    """Return whether the current interpreter is built in free-threaded mode."""
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+def test_expected_gil_build_mode_matches_ci_matrix():
+    """Validate interpreter mode expected by CI matrix."""
+    expected = os.getenv("SYMUSIC_EXPECT_GIL_DISABLED")
+    if expected is None:
+        pytest.skip("SYMUSIC_EXPECT_GIL_DISABLED not set")
+    assert _is_gil_disabled_build() is (expected == "1")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="Requires Python 3.14+")
+def test_jit_flag_is_safe_to_enable_when_available():
+    """Exercise import and object creation under optional PYTHON_JIT=1."""
+    if os.getenv("PYTHON_JIT") != "1":
+        pytest.skip("PYTHON_JIT is not enabled for this run")
+
+    jit_module = getattr(sys, "_jit", None)
+    if jit_module is None:
+        pytest.skip("sys._jit is unavailable on this interpreter")
+
+    score = Score(480)
+    track = Track("jit-track", 0, False)
+    track.notes.append(Note(0, 120, 60, 90))
+    score.tracks.append(track)
+    assert score.note_num() == 1
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="Requires Python 3.14+")
+def test_free_threaded_parallel_score_operations():
+    """Run parallel score operations as a free-threaded smoke test."""
+    if not _is_gil_disabled_build():
+        pytest.skip("This smoke test is only meaningful on free-threaded builds")
+
+    def _worker(seed: int) -> int:
+        score = Score(480)
+        track = Track(f"track-{seed}", 0, False)
+        for i in range(400):
+            track.notes.append(Note(i * 10, 5, (seed + i) % 128, 80))
+        score.tracks.append(track)
+        return score.note_num()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_worker, range(32)))
+
+    assert results == [400] * 32


### PR DESCRIPTION
### Motivation

- Validate library behavior on experimental Python 3.14 runtimes including the JIT-enabled and free-threaded (GIL-disabled) builds.

### Description

- Add a new GitHub Actions job `py314_experimental_runtime_test` that runs on `ubuntu-latest` for `3.14` (with optional JIT) and `3.14t` (free-threaded) matrix entries and exposes `PYTHON_JIT` and `SYMUSIC_EXPECT_GIL_DISABLED` to the test run.
- The new job prints runtime info, installs the package with test extras, and runs the full test suite with `pytest -s -n auto --durations=0 -v tests` under the experimental interpreter configurations.
- Add `tests/test_runtime_compatibility.py` which contains three tests: a check that the CI-provided expectation matches `Py_GIL_DISABLED`, a JIT-enabled import/object creation smoke test gated by `PYTHON_JIT`, and a free-threaded parallel score operations smoke test using `ThreadPoolExecutor`.

### Testing

- No automated test results are bundled with this change; the CI job `py314_experimental_runtime_test` is configured to run `pytest -s -n auto --durations=0 -v tests` and will report pass/fail when executed on the Actions runners.
- The added tests exercise interpreter-mode specific behaviors (GIL-disabled detection, optional `sys._jit` usage, and parallel score operations) and will be skipped automatically when the environment does not match the expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d669d290fc8333a6db51999cc2183a)